### PR TITLE
Deeplinks

### DIFF
--- a/web.py
+++ b/web.py
@@ -13,11 +13,17 @@ def entry():
     return render_template('input_page.html', result=False)
 
 @app.route('/', methods=['POST'])
-def submit():
+def submit():   
     #mysterious, but necessary step.  Without next line, request is null.
     #Alternative is to hard-code request MIME type, which is the "good" way...
+
     request.get_data()
     submitted_port = request.form['port_input']
+    return url_for('/port/' + submitted_port)
+
+@app.route('/port/<int:submitted_port>', methods=['GET'])
+def response(submitted_port):
+
     if submitted_port == '':
         return render_template('input_page.html', result=False)
         
@@ -35,6 +41,10 @@ def submit():
         result = "No service found!"
 
     return render_template('input_page.html', success=success, port=portInt, result=result)
+
+
+
+
 @app.route ('/healthcheck')
 def healthcheck():
     return 'ok'

--- a/web.py
+++ b/web.py
@@ -1,6 +1,6 @@
 import ports
 import os
-from flask import Flask, render_template, request, url_for, abort
+from flask import Flask, render_template, request, url_for, abort, redirect
 import waitress
 
 #if PORT env is specified, use that, otherwise use port 5000 flask default
@@ -15,14 +15,12 @@ def entry():
 @app.route('/', methods=['POST'])
 def submit():   
     #mysterious, but necessary step.  Without next line, request is null.
-    #Alternative is to hard-code request MIME type, which is the "good" way...
-
     request.get_data()
-    submitted_port = request.form['port_input']
-    return url_for('/port/' + submitted_port)
+    userinput = request.form['port_input']
+    return redirect(url_for('port_response', submitted_port=userinput), 303)
 
 @app.route('/port/<int:submitted_port>', methods=['GET'])
-def response(submitted_port):
+def port_response(submitted_port):
 
     if submitted_port == '':
         return render_template('input_page.html', result=False)
@@ -41,8 +39,6 @@ def response(submitted_port):
         result = "No service found!"
 
     return render_template('input_page.html', success=success, port=portInt, result=result)
-
-
 
 
 @app.route ('/healthcheck')


### PR DESCRIPTION
This PR changes the way results are displayed.  

Rather than getting the root page "/", POSTing to "/", then getting a response at "/", KnowYourPorts will provide an api-like response:
Initial view "/" will display input page.
POST will always occur to "/"
Upon hit, ports will display at the appropriate endpoint, e.g. "/port/22"

This provides a lot of extra functionality (like bookmarking) and will pave the road for other features too.  

This is deliberately not a true API specification or implementation of this project although that is a consideration for a later time.